### PR TITLE
Add CrewAI financial use case examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# Crew_AI_Agents
-Crew_AI_Agents
+# Crew AI Agents Financial Use Cases
+
+This repository contains example use cases for the [CrewAI](https://github.com/joaomdmoura/crewai) framework running with a local model via [Ollama](https://ollama.com/).
+Each folder demonstrates a simple agent crew setup for a specific problem in the financial industry.
+
+## Available Use Cases
+
+1. **use_case_01_fraud_detection** - Detect suspicious financial transactions.
+2. **use_case_02_risk_management** - Assess risk in derivative portfolios.
+3. **use_case_03_financial_reporting** - Generate automated financial reports.
+4. **use_case_04_portfolio_optimization** - Optimize investment portfolios.
+5. **use_case_05_bank_chatbot** - Provide a banking customer service chatbot.
+6. **use_case_06_compliance_monitoring** - Monitor transactions for compliance.
+7. **use_case_07_loan_default_prediction** - Predict the likelihood of loan defaults.
+8. **use_case_08_insider_trading_detection** - Spot potential insider trading.
+9. **use_case_09_algorithmic_trading** - Assist algorithmic trading strategy development.
+10. **use_case_10_insurance_claim_processing** - Automate insurance claim processing.
+
+Each directory includes a `README.md` and a `main.py` file. Make sure an Ollama server is running locally before executing the examples.

--- a/use_case_01_fraud_detection/README.md
+++ b/use_case_01_fraud_detection/README.md
@@ -1,0 +1,11 @@
+# Fraud Detection
+
+This example demonstrates how to build a simple fraud detection agent crew using a local Ollama model.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_01_fraud_detection/main.py
+++ b/use_case_01_fraud_detection/main.py
@@ -1,0 +1,27 @@
+"""Fraud Detection example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+# Connect to local Ollama model
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+fraud_agent = Agent(
+    role="Fraud Analyst",
+    goal="Identify suspicious financial transactions",
+    backstory="You analyze transaction logs to find patterns of fraud.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Analyze the latest transactions for fraudulent behavior.",
+    expected_output="A list of suspicious transactions with explanation.",
+    agent=fraud_agent,
+)
+
+crew = Crew(agents=[fraud_agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_02_risk_management/README.md
+++ b/use_case_02_risk_management/README.md
@@ -1,0 +1,12 @@
+
+# Risk Management
+
+Use a crew to assess risk in derivative portfolios.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_02_risk_management/main.py
+++ b/use_case_02_risk_management/main.py
@@ -1,0 +1,27 @@
+
+"""Risk Management example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Risk Management",
+    goal="Use a crew to assess risk in derivative portfolios.",
+    backstory="Agent for risk management.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Use a crew to assess risk in derivative portfolios.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_03_financial_reporting/README.md
+++ b/use_case_03_financial_reporting/README.md
@@ -1,0 +1,12 @@
+
+# Automated Financial Reporting
+
+Generate periodic financial reports automatically.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_03_financial_reporting/main.py
+++ b/use_case_03_financial_reporting/main.py
@@ -1,0 +1,27 @@
+
+"""Automated Financial Reporting example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Automated Financial Reporting",
+    goal="Generate periodic financial reports automatically.",
+    backstory="Agent for automated financial reporting.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Generate periodic financial reports automatically.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_04_portfolio_optimization/README.md
+++ b/use_case_04_portfolio_optimization/README.md
@@ -1,0 +1,12 @@
+
+# Portfolio Optimization
+
+Optimize investment portfolios using AI agents.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_04_portfolio_optimization/main.py
+++ b/use_case_04_portfolio_optimization/main.py
@@ -1,0 +1,27 @@
+
+"""Portfolio Optimization example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Portfolio Optimization",
+    goal="Optimize investment portfolios using AI agents.",
+    backstory="Agent for portfolio optimization.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Optimize investment portfolios using AI agents.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_05_bank_chatbot/README.md
+++ b/use_case_05_bank_chatbot/README.md
@@ -1,0 +1,12 @@
+
+# Bank Customer Service Chatbot
+
+Provide customer support for banking queries.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_05_bank_chatbot/main.py
+++ b/use_case_05_bank_chatbot/main.py
@@ -1,0 +1,27 @@
+
+"""Bank Customer Service Chatbot example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Bank Customer Service Chatbot",
+    goal="Provide customer support for banking queries.",
+    backstory="Agent for bank customer service chatbot.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Provide customer support for banking queries.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_06_compliance_monitoring/README.md
+++ b/use_case_06_compliance_monitoring/README.md
@@ -1,0 +1,12 @@
+
+# Compliance Monitoring
+
+Monitor transactions for regulatory compliance.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_06_compliance_monitoring/main.py
+++ b/use_case_06_compliance_monitoring/main.py
@@ -1,0 +1,27 @@
+
+"""Compliance Monitoring example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Compliance Monitoring",
+    goal="Monitor transactions for regulatory compliance.",
+    backstory="Agent for compliance monitoring.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Monitor transactions for regulatory compliance.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_07_loan_default_prediction/README.md
+++ b/use_case_07_loan_default_prediction/README.md
@@ -1,0 +1,12 @@
+
+# Loan Default Prediction
+
+Predict potential loan defaults.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_07_loan_default_prediction/main.py
+++ b/use_case_07_loan_default_prediction/main.py
@@ -1,0 +1,27 @@
+
+"""Loan Default Prediction example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Loan Default Prediction",
+    goal="Predict potential loan defaults.",
+    backstory="Agent for loan default prediction.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Predict potential loan defaults.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_08_insider_trading_detection/README.md
+++ b/use_case_08_insider_trading_detection/README.md
@@ -1,0 +1,12 @@
+
+# Insider Trading Detection
+
+Detect potential insider trading activities.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_08_insider_trading_detection/main.py
+++ b/use_case_08_insider_trading_detection/main.py
@@ -1,0 +1,27 @@
+
+"""Insider Trading Detection example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Insider Trading Detection",
+    goal="Detect potential insider trading activities.",
+    backstory="Agent for insider trading detection.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Detect potential insider trading activities.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_09_algorithmic_trading/README.md
+++ b/use_case_09_algorithmic_trading/README.md
@@ -1,0 +1,12 @@
+
+# Algorithmic Trading Assistant
+
+Assist in developing algorithmic trading strategies.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_09_algorithmic_trading/main.py
+++ b/use_case_09_algorithmic_trading/main.py
@@ -1,0 +1,27 @@
+
+"""Algorithmic Trading Assistant example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Algorithmic Trading Assistant",
+    goal="Assist in developing algorithmic trading strategies.",
+    backstory="Agent for algorithmic trading assistant.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Assist in developing algorithmic trading strategies.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)

--- a/use_case_10_insurance_claim_processing/README.md
+++ b/use_case_10_insurance_claim_processing/README.md
@@ -1,0 +1,12 @@
+
+# Insurance Claim Processing
+
+Automate processing of insurance claims.
+
+## Running the example
+
+```bash
+python main.py
+```
+
+Ensure that an Ollama server is running locally with the desired model.

--- a/use_case_10_insurance_claim_processing/main.py
+++ b/use_case_10_insurance_claim_processing/main.py
@@ -1,0 +1,27 @@
+
+"""Insurance Claim Processing example using CrewAI with Ollama."""
+
+from crewai import Agent, Task, Crew
+from langchain.llms import Ollama
+
+llm = Ollama(model="llama3", base_url="http://localhost:11434")
+
+agent = Agent(
+    role="Insurance Claim Processing",
+    goal="Automate processing of insurance claims.",
+    backstory="Agent for insurance claim processing.",
+    allow_delegation=False,
+    llm=llm,
+)
+
+task = Task(
+    description="Automate processing of insurance claims.",
+    expected_output="Result of the task.",
+    agent=agent,
+)
+
+crew = Crew(agents=[agent], tasks=[task])
+
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)


### PR DESCRIPTION
## Summary
- add 10 sample use cases for the financial industry
- link CrewAI with Ollama local model in each example
- update repo README with list of all use cases

## Testing
- `find . -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_683f646007b08331a429fcddbf163f9d