### PR TITLE
Add subfolder level for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Crew_AI_Agents
-Crew_AI_Agents
+
+This repository contains examples and documentation for using `crewai` agents.
+
+* **[USE_CASES.md](USE_CASES.md)** – A list of ten research use cases that
+  demonstrate how to leverage a local model via Ollama with knowledge graphs.
+* **examples/basic/knowledge_graph_example.py** – Minimal script showing how agents
+  could build a lightweight knowledge graph and query it.
+* **examples/use_cases/** – Folders containing sample code for each of the ten
+  research workflows described in `USE_CASES.md`. Each use case now places its
+  implementation under a `src/` subfolder for additional structure.

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -1,0 +1,55 @@
+# CrewAI Research Use Cases with Ollama
+
+The following use cases demonstrate how `crewai` agents running with a local model via **Ollama** can accelerate research workflows. A central theme is leveraging **knowledge graphs** to organize information and employing agents to explore new ideas and manage tasks.
+
+1. **Knowledge Graph Creation**
+   - Parse research papers, web articles, or datasets using the local model and ingest key entities (authors, topics, methods) into a knowledge graph.
+   - Agents continuously expand the graph with new data sources, ensuring up-to-date context for research questions.
+   - Example: `examples/use_cases/use_case_01/src/main.py`
+
+2. **Accelerated Querying**
+   - Use the knowledge graph to answer complex research queries rapidly.
+   - Agents traverse the graph to surface relevant papers, datasets, or relationships, providing short summaries.
+   - Example: `examples/use_cases/use_case_02/src/main.py`
+
+3. **Idea Incubation**
+   - Deploy a brainstorming agent that examines the graph to discover gaps or unexplored connections.
+   - The agent suggests new project ideas or hypotheses based on relationships found within the knowledge graph.
+   - Example: `examples/use_cases/use_case_03/src/main.py`
+
+4. **Automated Literature Review**
+   - Agents scan the graph for recent publications and generate concise literature reviews.
+   - By analyzing citation networks, they highlight influential works and trends.
+   - Example: `examples/use_cases/use_case_04/src/main.py`
+
+5. **Experiment Design Assistance**
+   - Agents analyze existing methods stored in the knowledge graph to recommend experiment designs or analytical approaches.
+   - This includes identifying standard protocols, datasets, or software libraries relevant to the research topic.
+   - Example: `examples/use_cases/use_case_05/src/main.py`
+
+6. **Grant Proposal Support**
+   - Agents gather background research from the knowledge graph to craft persuasive grant proposals.
+   - They provide references and evidence of research needs directly from the graph's curated information.
+   - Example: `examples/use_cases/use_case_06/src/main.py`
+
+7. **Collaboration Network Mapping**
+   - Agents map relationships between researchers, institutions, and projects.
+   - This helps identify potential collaborators or experts in a specific domain.
+   - Example: `examples/use_cases/use_case_07/src/main.py`
+
+8. **Data Integration with Ontologies**
+   - Agents merge data from various sources into the knowledge graph using domain-specific ontologies.
+   - This keeps terminology consistent and makes cross-dataset queries more effective.
+   - Example: `examples/use_cases/use_case_08/src/main.py`
+
+9. **Real-time Research Updates**
+   - Monitoring agents watch for new publications or datasets, ingesting them into the graph automatically.
+   - Researchers receive alerts when new, relevant work appears.
+   - Example: `examples/use_cases/use_case_09/src/main.py`
+
+10. **Interdisciplinary Connection Finder**
+    - Agents explore the knowledge graph to find links between seemingly unrelated fields.
+    - This can reveal opportunities for novel collaborations or cross-domain insights.
+    - Example: `examples/use_cases/use_case_10/src/main.py`
+
+These use cases illustrate how combining `crewai` agents with a knowledge graph—powered by a local model through Ollama—can streamline research tasks, from idea generation to ongoing literature monitoring.

--- a/examples/basic/knowledge_graph_example.py
+++ b/examples/basic/knowledge_graph_example.py
@@ -1,0 +1,58 @@
+"""Example knowledge graph workflow using crewai with a local model via Ollama.
+
+This script parses a few documents and builds a very simple knowledge graph.
+It then performs a trivial query to demonstrate how the graph could be used to
+speed up research tasks.
+
+The example avoids heavy dependencies and serves as an outline for integrating
+crewai agents with a local language model. Replace the placeholder logic with
+actual calls to `crewai` and your model of choice.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    """Simple document structure."""
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    """Stores a lightweight knowledge graph of documents and keywords."""
+
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        """Add documents to the graph linking titles to keywords."""
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="keyword")
+                self.graph.add_edge(doc.title, word)
+
+    def query(self, keyword: str) -> List[str]:
+        """Return document titles related to a keyword."""
+        if keyword not in self.graph:
+            return []
+        return [nbr for nbr in self.graph.neighbors(keyword) if self.graph.nodes[nbr]["type"] == "document"]
+
+
+def main() -> None:
+    docs = [
+        Document(title="LLM Knowledge Graphs", content="using llms to build knowledge graphs"),
+        Document(title="Research Agents", content="agents automate research tasks"),
+    ]
+
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+
+    related = agent.query("research")
+    print("Documents related to 'research':", related)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_01/src/main.py
+++ b/examples/use_cases/use_case_01/src/main.py
@@ -1,0 +1,39 @@
+"""Use Case 1: Knowledge Graph Creation
+
+Build a small knowledge graph from example documents using a simple agent.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="keyword")
+                self.graph.add_edge(doc.title, word)
+
+
+def main() -> None:
+    docs = [
+        Document(title="LLM Knowledge Graphs", content="using llms to build knowledge graphs"),
+        Document(title="Research Agents", content="agents automate research tasks"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    print("Nodes:", list(agent.graph.nodes()))
+    print("Edges:", list(agent.graph.edges()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_02/src/main.py
+++ b/examples/use_cases/use_case_02/src/main.py
@@ -1,0 +1,43 @@
+"""Use Case 2: Accelerated Querying
+
+Query the knowledge graph for documents related to a specific keyword.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="keyword")
+                self.graph.add_edge(doc.title, word)
+
+    def query(self, keyword: str) -> List[str]:
+        if keyword not in self.graph:
+            return []
+        return [n for n in self.graph.neighbors(keyword) if self.graph.nodes[n]["type"] == "document"]
+
+
+def main() -> None:
+    docs = [
+        Document(title="LLM Knowledge Graphs", content="using llms to build knowledge graphs"),
+        Document(title="Research Agents", content="agents automate research tasks"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    print("Documents related to 'research':", agent.query("research"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_03/src/main.py
+++ b/examples/use_cases/use_case_03/src/main.py
@@ -1,0 +1,49 @@
+"""Use Case 3: Idea Incubation
+
+Analyze the knowledge graph to identify potential research ideas based on
+missing connections between topics.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="keyword")
+                self.graph.add_edge(doc.title, word)
+
+    def suggest_new_links(self) -> List[tuple[str, str]]:
+        suggestions = []
+        keywords = [n for n, d in self.graph.nodes(data=True) if d["type"] == "keyword"]
+        for i, kw1 in enumerate(keywords):
+            for kw2 in keywords[i + 1 :]:
+                if not self.graph.has_edge(kw1, kw2):
+                    suggestions.append((kw1, kw2))
+        return suggestions
+
+
+def main() -> None:
+    docs = [
+        Document(title="LLM Knowledge Graphs", content="using llms to build knowledge graphs"),
+        Document(title="Research Agents", content="agents automate research tasks"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    ideas = agent.suggest_new_links()
+    print("Possible new topic links:", ideas)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_04/src/main.py
+++ b/examples/use_cases/use_case_04/src/main.py
@@ -1,0 +1,40 @@
+"""Use Case 4: Automated Literature Review
+
+Generate a brief summary of documents stored in the knowledge graph.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, Dict
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document", content=doc.content)
+
+    def summarize(self) -> Dict[str, str]:
+        return {n: self.graph.nodes[n]["content"][:50] for n, d in self.graph.nodes(data=True) if d["type"] == "document"}
+
+
+def main() -> None:
+    docs = [
+        Document(title="LLM Knowledge Graphs", content="using llms to build knowledge graphs"),
+        Document(title="Research Agents", content="agents automate research tasks"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    summaries = agent.summarize()
+    for title, snippet in summaries.items():
+        print(f"{title}: {snippet}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_05/src/main.py
+++ b/examples/use_cases/use_case_05/src/main.py
@@ -1,0 +1,42 @@
+"""Use Case 5: Experiment Design Assistance
+
+Recommend experimental methods based on existing entries in the knowledge graph.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="method")
+                self.graph.add_edge(doc.title, word)
+
+    def recommend_methods(self) -> List[str]:
+        methods = [n for n, d in self.graph.nodes(data=True) if d["type"] == "method"]
+        return sorted(set(methods))
+
+
+def main() -> None:
+    docs = [
+        Document(title="Image Classification", content="use cnn and torch"),
+        Document(title="Graph Analysis", content="apply networkx and centrality"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    print("Suggested methods:", agent.recommend_methods())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_06/src/main.py
+++ b/examples/use_cases/use_case_06/src/main.py
@@ -1,0 +1,43 @@
+"""Use Case 6: Grant Proposal Support
+
+Gather references from the knowledge graph to incorporate into a grant proposal.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class KnowledgeGraphAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+            for word in set(doc.content.lower().split()):
+                self.graph.add_node(word, type="keyword")
+                self.graph.add_edge(doc.title, word)
+
+    def collect_references(self, topic: str) -> List[str]:
+        if topic not in self.graph:
+            return []
+        return [n for n in self.graph.neighbors(topic) if self.graph.nodes[n]["type"] == "document"]
+
+
+def main() -> None:
+    docs = [
+        Document(title="Funding Strategies", content="grant writing research"),
+        Document(title="Knowledge Graph Benefits", content="knowledge graph research"),
+    ]
+    agent = KnowledgeGraphAgent()
+    agent.ingest(docs)
+    print("References for 'research':", agent.collect_references("research"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_07/src/main.py
+++ b/examples/use_cases/use_case_07/src/main.py
@@ -1,0 +1,43 @@
+"""Use Case 7: Collaboration Network Mapping
+
+Create a network of researchers and institutions to discover potential collaborators.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, Tuple, List
+import networkx as nx
+
+@dataclass
+class Collaboration:
+    researcher: str
+    institution: str
+
+class CollaborationAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, records: Iterable[Collaboration]) -> None:
+        for rec in records:
+            self.graph.add_node(rec.researcher, type="researcher")
+            self.graph.add_node(rec.institution, type="institution")
+            self.graph.add_edge(rec.researcher, rec.institution)
+
+    def find_institutions(self, researcher: str) -> List[str]:
+        if researcher not in self.graph:
+            return []
+        return [n for n in self.graph.neighbors(researcher) if self.graph.nodes[n]["type"] == "institution"]
+
+
+def main() -> None:
+    records = [
+        Collaboration("Alice", "University A"),
+        Collaboration("Bob", "University B"),
+        Collaboration("Alice", "Research Lab X"),
+    ]
+    agent = CollaborationAgent()
+    agent.ingest(records)
+    print("Institutions for Alice:", agent.find_institutions("Alice"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_08/src/main.py
+++ b/examples/use_cases/use_case_08/src/main.py
@@ -1,0 +1,38 @@
+"""Use Case 8: Data Integration with Ontologies
+
+Combine datasets under a common ontology within the knowledge graph.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable
+import networkx as nx
+
+@dataclass
+class DataEntry:
+    id: str
+    term: str
+    dataset: str
+
+class OntologyAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, entries: Iterable[DataEntry]) -> None:
+        for entry in entries:
+            self.graph.add_node(entry.term, dataset=entry.dataset)
+            self.graph.add_node(entry.dataset, type="dataset")
+            self.graph.add_edge(entry.dataset, entry.term)
+
+
+def main() -> None:
+    entries = [
+        DataEntry("1", "protein", "bio"),
+        DataEntry("2", "protein", "chem"),
+    ]
+    agent = OntologyAgent()
+    agent.ingest(entries)
+    print("Nodes:", list(agent.graph.nodes(data=True)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_09/src/main.py
+++ b/examples/use_cases/use_case_09/src/main.py
@@ -1,0 +1,37 @@
+"""Use Case 9: Real-time Research Updates
+
+Simulate monitoring new documents and automatically adding them to the knowledge graph.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+
+class UpdateAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, type="document")
+
+    def monitor_and_add(self, new_doc: Document) -> None:
+        self.ingest([new_doc])
+        print(f"Added {new_doc.title}")
+
+
+def main() -> None:
+    initial = [Document("Start", "baseline")]
+    agent = UpdateAgent()
+    agent.ingest(initial)
+    agent.monitor_and_add(Document("New Research", "latest findings"))
+    print("Documents:", [n for n in agent.graph.nodes()])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/use_case_10/src/main.py
+++ b/examples/use_cases/use_case_10/src/main.py
@@ -1,0 +1,51 @@
+"""Use Case 10: Interdisciplinary Connection Finder
+
+Search the knowledge graph for links between distinct research fields.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+import networkx as nx
+
+@dataclass
+class Document:
+    title: str
+    content: str
+    field: str
+
+class ConnectionAgent:
+    def __init__(self) -> None:
+        self.graph = nx.Graph()
+
+    def ingest(self, docs: Iterable[Document]) -> None:
+        for doc in docs:
+            self.graph.add_node(doc.title, field=doc.field)
+            self.graph.add_node(doc.field, type="field")
+            self.graph.add_edge(doc.title, doc.field)
+
+    def cross_field_links(self) -> List[tuple[str, str]]:
+        fields = [n for n, d in self.graph.nodes(data=True) if d.get("type") == "field"]
+        links = []
+        for doc1, data1 in self.graph.nodes(data=True):
+            if data1.get("type") == "field":
+                continue
+            for doc2, data2 in self.graph.nodes(data=True):
+                if data2.get("type") == "field" or doc1 == doc2:
+                    continue
+                if data1["field"] != data2["field"]:
+                    links.append((doc1, doc2))
+        return links
+
+
+def main() -> None:
+    docs = [
+        Document("Graph Mining", "techniques", "Computer Science"),
+        Document("Protein Analysis", "biology", "Biology"),
+    ]
+    agent = ConnectionAgent()
+    agent.ingest(docs)
+    print("Cross-field document pairs:", agent.cross_field_links())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move knowledge_graph_example.py into `examples/basic/`
- nest each use case script under a new `src/` directory
- update README and USE_CASES paths accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6441ff3483319d69f3d69a4f2601